### PR TITLE
feat: Health Endpoint for AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ poetry install
 quart --app api --debug run
 ```
 
+You can use `/health` endpoint to check if the system is running or not. 
+
 ## Poetry Fixes
 
 ```shell

--- a/api.py
+++ b/api.py
@@ -109,3 +109,16 @@ async def startup():
 
 # quart --app api --debug run
 # hypercorn api -b 0.0.0.0:8000
+
+@app.route("/health", methods=["GET"])
+def health():
+    """
+    Get health status of AI Tools
+    ---
+    tags:
+      - health
+    responses:
+      200:
+            description: A status check for AI Tools
+    """
+    return "<p>AI Tools are active.</p>", 200


### PR DESCRIPTION
## Description
I have added a new API endpoint `\health`. With the help of this API endpoint users can verify their server status by directly making a call to this endpoint. The endpoint will return a simple string that will consume the minimum Bandwith of the user.

Fixes #58 