### PR TITLE
there is a syntax error in ai-tools/test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from src.text_lang_detection.bhashini.remote import *
 import asyncio, aiohttp, time
 from quart import Quart


### PR DESCRIPTION
When I run ai-tools/test.py file, facing this issue: 
SyntaxError: Non-UTF-8 code starting with '\xe0' in file c:\Users\harshinirhsv\ai-tools\test.py on line 5, but no encoding declared; see https://python.org/dev/peps/pep-0263/ for details

Regarding this issue: To fix this Syntax Error , we should add code '# -*- coding:utf-8 -*-' at the top of the python script.