### PR TITLE
Health check api

### DIFF
--- a/src/asr/google/remote/api.py
+++ b/src/asr/google/remote/api.py
@@ -12,6 +12,10 @@ app = Quart(__name__)
 async def startup():
     app.client = aiohttp.ClientSession()
 
+@app.route('/health') # this endpoint returns health of the particular model
+def health():
+    return "up" # custom checks can be written to indicate various cases
+
 @app.route('/transcript', methods=['POST'])
 async def translate():
     data = await request.get_json()


### PR DESCRIPTION
Fixes #58 
Added a health check API, which checks the health status of all the deployed models using `config.json`.
I have also added a test code in `src/asr/google/remote/api.py` which can be modified to add custom tests for determining whether the particular service is up or down. If the PR is merged, we need to have a `/health` endpoint in each of the deployed model's `api.py` files.
